### PR TITLE
Use GNU readline for interactive shell

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,7 @@ AC_PROG_LN_S
 AC_PROG_EGREP
 
 # Dependencies
+AC_CHECK_HEADERS([readline/readline.h readline/history.h],,[AC_MSG_ERROR([cannot find readline headers])])
 PKG_CHECK_MODULES([GLFS], [glusterfs-api >= 3],,[AC_MSG_ERROR([cannot find glusterfs api headers])])
 
 AC_CHECK_PROG([HAVE_HELP2MAN],[help2man],[yes],[no])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,7 +40,7 @@ __top_builddir__build_bin_gfcli_SOURCES = glfs-cli.c \
 					  glfs-util.c
 
 __top_builddir__build_bin_gfcli_CFLAGS = $(GLFS_CFLAGS)
-__top_builddir__build_bin_gfcli_LDADD = $(LDADD) $(GLFS_LIBS)
+__top_builddir__build_bin_gfcli_LDADD = $(LDADD) $(GLFS_LIBS) -lreadline
 
 __top_builddir__build_bin_gfput_SOURCES = glfs-put.c glfs-util.c
 __top_builddir__build_bin_gfput_CFLAGS = $(GLFS_CFLAGS)


### PR DESCRIPTION
Previously, we were using the basic getline() function to retrieve input from the user for the interactive shell gfcli(1). This was suboptimal since it makes adding extra features such as shell history more tedious.

This changes introduces basic shell history courtesy of the GNU history library. History is not persistent across different sessions of the shell, only within a session.