### PR TITLE
cli: ignore unknown options

### DIFF
--- a/src/glfs-cli.c
+++ b/src/glfs-cli.c
@@ -253,6 +253,10 @@ parse_options (struct cli_context *ctx)
         int option_index = 0;
         struct xlator_option *option;
 
+        // Ignore unknown options in order to allow them to be passed
+        // through to the underlying utility or cli-specific command.
+        opterr = 0;
+
         while (true) {
                 opt = getopt_long (argc, argv, "o:", long_options,
                                 &option_index);
@@ -288,6 +292,8 @@ parse_options (struct cli_context *ctx)
                                                 LICENSE,
                                                 AUTHORS);
                                 exit (EXIT_SUCCESS);
+                        case '?':
+                                break;
                         case 'x':
                                 usage ();
                         default:


### PR DESCRIPTION
The cli has its own argument parser in order to allow for additional functionality. However, it was catching unknown arguments. This is undesirable because underlying commands which will be called (such as `connect') in certain situations were blocked by getopt() from ever being executed.